### PR TITLE
Close ports 6666 and 80 by default with CSF; open 443

### DIFF
--- a/roles/csf/defaults/main.yml
+++ b/roles/csf/defaults/main.yml
@@ -1,11 +1,11 @@
 csf_testing: 0
 csf_testing_interval: 5
-csf_tcp_in: "22,80,6666"
-csf_tcp_out: "22,80,6666"
+csf_tcp_in: "22"
+csf_tcp_out: "22,443"
 csf_udp_in: ""
 csf_udp_out: ""
-csf_tcp6_in: "22,80,6666"
-csf_tcp6_out: "22,80,6666"
+csf_tcp6_in: "22"
+csf_tcp6_out: "22"
 csf_udp6_in: ""
 csf_udp6_out: ""
 csf_lf_alert_to: ""


### PR DESCRIPTION
IRC and HTTP will not be needed on all servers; 443 (SSL) is needed
by pip and other services (as discussed with @lyndsysimon)
