### PR TITLE
Fixes csf | install.

### DIFF
--- a/roles/csf/tasks/main.yml
+++ b/roles/csf/tasks/main.yml
@@ -18,7 +18,7 @@
   when: check_path.stat.exists == false
 
 - name: csf | install
-  command: cd /tmp/csf/; sh install.sh
+  command: sh install.sh chdir=/tmp/csf/
   sudo: yes
   when: check_path.stat.exists == false
 


### PR DESCRIPTION
 Note: cd does not work for command. use chdir= or the shell module.
