### PR TITLE
Download CSF over HTTPS

### DIFF
--- a/roles/csf/tasks/main.yml
+++ b/roles/csf/tasks/main.yml
@@ -8,7 +8,7 @@
   register: check_path
 
 - name: download csf
-  get_url: url=http://www.configserver.com/free/csf.tgz dest=/tmp/
+  get_url: url=https://download.configserver.com/csf.tgz dest=/tmp/
   when: check_path.stat.exists == false
 
 - command: tar -xzf /tmp/csf.tgz -C /tmp/


### PR DESCRIPTION
CSF now provides a secure download link, which is greatly preferred over HTTP