### PR TITLE
[WIP] Sample docker deployment changes to build ember-LEI apps in prod mode

### DIFF
--- a/docker-spa.yml
+++ b/docker-spa.yml
@@ -9,7 +9,7 @@
     docker_experimenter_working_dir: /experimenter/
     docker_experimenter_name: "{{ docker_env }}_experimenter_1"
     docker_experimenter_image: centerforopenscience/ember:latest
-    docker_experimenter_command: gosu www-data ember build --env staging
+    docker_experimenter_command: gosu www-data ember build --env production
     docker_experimenter_source_conf_dir: roles/docker-spa/files/experimenter/
     docker_experimenter_code_dir: "/opt/{{ docker_env }}_experimenter/code/"
     docker_experimenter_conf_dir: "/opt/{{ docker_env }}_experimenter/conf/"
@@ -31,7 +31,7 @@
     docker_isp_working_dir: /isp/
     docker_isp_name: "{{ docker_env }}_isp_1"
     docker_isp_image: centerforopenscience/ember:latest
-    docker_isp_command: gosu www-data ember build --env staging
+    docker_isp_command: gosu www-data ember build --env production
     docker_isp_source_conf_dir: roles/docker-spa/files/isp/
     docker_isp_code_dir: "/opt/{{ docker_env }}_isp/code/"
     docker_isp_conf_dir: "/opt/{{ docker_env }}_isp/conf/"
@@ -53,7 +53,7 @@
     docker_lookit_working_dir: /lookit/
     docker_lookit_name: "{{ docker_env }}_lookit_1"
     docker_lookit_image: centerforopenscience/ember:latest
-    docker_lookit_command: gosu www-data ember build --env staging
+    docker_lookit_command: gosu www-data ember build --env production
     docker_lookit_source_conf_dir: roles/docker-spa/files/lookit/
     docker_lookit_code_dir: "/opt/{{ docker_env }}_lookit/code/"
     docker_lookit_conf_dir: "/opt/{{ docker_env }}_lookit/conf/"

--- a/roles/docker-ember/defaults/main.yml
+++ b/roles/docker-ember/defaults/main.yml
@@ -7,7 +7,7 @@ docker_ember_working_dir: /<CHANGE>/
 docker_ember: no
 docker_ember_name: ember_1
 docker_ember_image: centerforopenscience/<CHANGE>:latest
-docker_ember_command: gosu www-data ember build --env staging
+docker_ember_command: gosu www-data ember build --env production
 docker_ember_source_conf_dir: roles/docker-ember/files/
 docker_ember_code_dir: /opt/ember/code/
 docker_ember_conf_dir: /opt/ember/conf/


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/LEI-275

Server deployments should never be run according to debug / local dev settings- the ember-cli `--environment` flag should be used for build and test control only.

Changes the default for Lookit/experimenter/isp apps, and also changes the settings for default apps. (ember-cli has no known meaning for "staging" and therefore defaults to buildings apps in debug mode)

Being new to this repo, I will look over these proposed changes with @mattclark for accuracy and completeness.


https://ember-cli.com/user-guide/#Environments
> Ember-CLI ships with support for managing your application’s environment. Ember-CLI will build an environment config file at config/environment. Here, you can define an ENV object for each environment (development, test and production). For now, this is limited to the three environments mentioned.